### PR TITLE
Fix: download link for latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you have any questions refer to [FAQ](https://drive.google.com/open?id=1BTU3B
 
 ## Getting started for users
 Currently available latest version 1.8 can be downloaded by one of the following links:
- - [Desktop application v1.8](https://github.com/osrmt/osrmt/releases/download/1.8/osrmt_1.8_deskto
+ - [Desktop application v1.8](https://github.com/osrmt/osrmt/releases/download/1.8/osrmt_1.8_desktop.zip)
 
 ### Pre-installation requirements
  - Windows, Linux or MacOS


### PR DESCRIPTION
Download link for users is incorrect in **Getting started for users** section.

It's correct at the start of the README.md and master branch but develop is default branch.
